### PR TITLE
#WIP Destroy user methods fix

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,8 @@ class UsersController < ApplicationController
 
   private
 
+
+# This is not used by non admin user. It needs fixing and specs to test it.
   def delete_possible?(user)
     if user.nil?
       return false


### PR DESCRIPTION
<h1>Purpose</h1>
We have discovered that in the users controller the method delete_possible? is not used by a normal user to delete himself. Instead a devise method is employed. This method should not allow a normal user to delete any other users, and by the looks of it it will not allow a user to delete himself. We need @alexvkcr  @agarciavera @sebjimenez @sergio-ocon @delaluzparra 