### PR TITLE
Fixed hakiri error by updating rack gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ end
 # Add rack specific version to fix deployment error
 # in OpenShift online
 
-gem 'rack', '1.5.2'
+gem 'rack'
 
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.5.2)
+    rack (1.5.5)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.1.16)
@@ -277,7 +277,7 @@ DEPENDENCIES
   minitest-reporters
   patternfly-sass (~> 3.8.0)
   pg
-  rack (= 1.5.2)
+  rack
   rails (~> 4.1)
   rake
   rspec-rails (~> 3.4)


### PR DESCRIPTION
<h1>Purpose</h1>
Version 1.5.2 of the rack gem has a vulnerability that could allow a DDos attack. Solution: editing the gemfile by removing: gem 'rack', '1.5.2 ' and leaving just: gem 'rack'; bundle update rack afterwords and it's done. Version 1.5.5 is installed with the "bundle update rack" command.
@sergio-ocon @sebjimenez @agarciavera @alexvkcr 
This is ready to merge.